### PR TITLE
Improve Network Visualization for Gene Symbol Pages

### DIFF
--- a/TSUMUGI/template/template-app-js/template_app.js
+++ b/TSUMUGI/template/template-app-js/template_app.js
@@ -60,24 +60,48 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "XXX_ELEMENTS".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
+
 let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
+    defaultNodeRepulsion,
     nodeRepulsionMin,
     nodeRepulsionMax,
 );
 
 let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
+    defaultNodeRepulsion,
     componentSpacingMin,
     componentSpacingMax,
 );
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+    
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100,           // Increase ideal edge length for better spacing
+            nodeOverlap: 20,                // Increase to prevent node overlap
+            padding: 30,                    // Add padding around the layout
+            animate: true,                  // Enable animation for better visual feedback
+            animationDuration: 500,         // Animation duration in ms
+            gravity: -1.2,                  // Negative gravity to push nodes apart
+            numIter: 1500,                  // More iterations for better layout
+            initialTemp: 200,               // Higher initial temperature for better spreading
+            coolingFactor: 0.95,            // Slower cooling for better results
+            minTemp: 1.0,                   // Minimum temperature threshold
+            edgeElasticity: 100,            // Edge elasticity for better edge distribution
+        };
+    }
+    
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -90,7 +114,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -251,7 +275,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -263,7 +287,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -288,7 +312,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/genelist/network_genelist.js
+++ b/test-tsumugi/app/genelist/network_genelist.js
@@ -59,24 +59,40 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "JSON.parse(localStorage.getItem('elements'))".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -89,7 +105,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -306,7 +322,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -318,7 +334,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -343,7 +359,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/genesymbol/Dstn.js
+++ b/test-tsumugi/app/genesymbol/Dstn.js
@@ -102,24 +102,40 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "loadJSONGz('../../data/genesymbol/Dstn.json.gz')".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -132,7 +148,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -369,7 +385,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -381,7 +397,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -406,7 +422,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/genesymbol/Ints8.js
+++ b/test-tsumugi/app/genesymbol/Ints8.js
@@ -102,24 +102,40 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "loadJSONGz('../../data/genesymbol/Ints8.json.gz')".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -132,7 +148,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -369,7 +385,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -381,7 +397,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -406,7 +422,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/genesymbol/Kcnma1.js
+++ b/test-tsumugi/app/genesymbol/Kcnma1.js
@@ -102,24 +102,40 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "loadJSONGz('../../data/genesymbol/Kcnma1.json.gz')".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -132,7 +148,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -369,7 +385,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -381,7 +397,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -406,7 +422,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/genesymbol/Plekha8.js
+++ b/test-tsumugi/app/genesymbol/Plekha8.js
@@ -102,24 +102,40 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "loadJSONGz('../../data/genesymbol/Plekha8.json.gz')".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -132,7 +148,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -369,7 +385,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -381,7 +397,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -406,7 +422,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/genesymbol/Trappc11.js
+++ b/test-tsumugi/app/genesymbol/Trappc11.js
@@ -102,24 +102,40 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "loadJSONGz('../../data/genesymbol/Trappc11.json.gz')".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -132,7 +148,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -369,7 +385,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -381,7 +397,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -406,7 +422,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/genesymbol/Zfp39.js
+++ b/test-tsumugi/app/genesymbol/Zfp39.js
@@ -102,24 +102,40 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "loadJSONGz('../../data/genesymbol/Zfp39.json.gz')".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -132,7 +148,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -369,7 +385,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -381,7 +397,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -406,7 +422,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/phenotype/convulsive_seizures.js
+++ b/test-tsumugi/app/phenotype/convulsive_seizures.js
@@ -125,24 +125,40 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "loadJSONGz('../../data/phenotype/convulsive_seizures.json.gz')".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -155,7 +171,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -373,7 +389,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -385,7 +401,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -410,7 +426,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/phenotype/edema.js
+++ b/test-tsumugi/app/phenotype/edema.js
@@ -59,24 +59,40 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "loadJSONGz('../../data/phenotype/edema.json.gz')".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -89,7 +105,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -295,7 +311,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -307,7 +323,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -332,7 +348,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/phenotype/increased_blood_urea_nitrogen_level.js
+++ b/test-tsumugi/app/phenotype/increased_blood_urea_nitrogen_level.js
@@ -125,24 +125,42 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "loadJSONGz('../../data/phenotype/increased_blood_urea_nitrogen_level.json.gz')".includes(
+    "genesymbol",
 );
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -155,7 +173,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -373,7 +391,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -385,7 +403,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -410,7 +428,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/phenotype/increased_circulating_glycerol_level.js
+++ b/test-tsumugi/app/phenotype/increased_circulating_glycerol_level.js
@@ -125,24 +125,42 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "loadJSONGz('../../data/phenotype/increased_circulating_glycerol_level.json.gz')".includes(
+    "genesymbol",
 );
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -155,7 +173,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -373,7 +391,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -385,7 +403,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -410,7 +428,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/phenotype/increased_fasting_circulating_glucose_level.js
+++ b/test-tsumugi/app/phenotype/increased_fasting_circulating_glucose_level.js
@@ -125,24 +125,41 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage =
+    "loadJSONGz('../../data/phenotype/increased_fasting_circulating_glucose_level.json.gz')".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -155,7 +172,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -373,7 +390,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -385,7 +402,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -410,7 +427,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/phenotype/male_infertility.js
+++ b/test-tsumugi/app/phenotype/male_infertility.js
@@ -59,24 +59,40 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage = "loadJSONGz('../../data/phenotype/male_infertility.json.gz')".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -89,7 +105,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -295,7 +311,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -307,7 +323,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -332,7 +348,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;

--- a/test-tsumugi/app/phenotype/preweaning_lethality,_complete_penetrance.js
+++ b/test-tsumugi/app/phenotype/preweaning_lethality,_complete_penetrance.js
@@ -59,24 +59,41 @@ const nodeRepulsionMax = 10000;
 const componentSpacingMin = 1;
 const componentSpacingMax = 200;
 
-let nodeRepulsionValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    nodeRepulsionMin,
-    nodeRepulsionMax,
-);
+// Use different defaults for gene symbol pages only
+const isGeneSymbolPage =
+    "loadJSONGz('../../data/phenotype/preweaning_lethality,_complete_penetrance.json.gz')".includes("genesymbol");
+const defaultNodeRepulsion = isGeneSymbolPage ? 8 : 5;
 
-let componentSpacingValue = scaleToOriginalRange(
-    parseFloat(document.getElementById("nodeRepulsion-slider").value),
-    componentSpacingMin,
-    componentSpacingMax,
-);
+let nodeRepulsionValue = scaleToOriginalRange(defaultNodeRepulsion, nodeRepulsionMin, nodeRepulsionMax);
+
+let componentSpacingValue = scaleToOriginalRange(defaultNodeRepulsion, componentSpacingMin, componentSpacingMax);
 
 function getLayoutOptions() {
-    return {
+    const baseOptions = {
         name: currentLayout,
         nodeRepulsion: nodeRepulsionValue,
         componentSpacing: componentSpacingValue,
     };
+
+    // Add enhanced options for COSE layout to prevent hairball effect (gene symbol pages only)
+    if (currentLayout === "cose" && isGeneSymbolPage) {
+        return {
+            ...baseOptions,
+            idealEdgeLength: 100, // Increase ideal edge length for better spacing
+            nodeOverlap: 20, // Increase to prevent node overlap
+            padding: 30, // Add padding around the layout
+            animate: true, // Enable animation for better visual feedback
+            animationDuration: 500, // Animation duration in ms
+            gravity: -1.2, // Negative gravity to push nodes apart
+            numIter: 1500, // More iterations for better layout
+            initialTemp: 200, // Higher initial temperature for better spreading
+            coolingFactor: 0.95, // Slower cooling for better results
+            minTemp: 1.0, // Minimum temperature threshold
+            edgeElasticity: 100, // Edge elasticity for better edge distribution
+        };
+    }
+
+    return baseOptions;
 }
 
 const cy = cytoscape({
@@ -89,7 +106,7 @@ const cy = cytoscape({
                 label: "data(label)",
                 "text-valign": "center",
                 "text-halign": "center",
-                "font-size": "20px",
+                "font-size": isGeneSymbolPage ? "10px" : "20px",
                 width: 15,
                 height: 15,
                 "background-color": function (ele) {
@@ -295,7 +312,7 @@ setupPhenotypeSearch({ cy, elements });
 // Slider for Font size
 // --------------------------------------------------------
 
-createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
+createSlider("font-size-slider", isGeneSymbolPage ? 10 : 20, 1, 50, 1, (intValues) => {
     document.getElementById("font-size-value").textContent = intValues;
     cy.style()
         .selector("node")
@@ -307,7 +324,7 @@ createSlider("font-size-slider", 20, 1, 50, 1, (intValues) => {
 // Slider for Edge width
 // --------------------------------------------------------
 
-createSlider("edge-width-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("edge-width-slider", isGeneSymbolPage ? 2 : 5, 1, 10, 1, (intValues) => {
     document.getElementById("edge-width-value").textContent = intValues;
     cy.style()
         .selector("edge")
@@ -332,7 +349,7 @@ function updateNodeRepulsionVisibility() {
 updateNodeRepulsionVisibility();
 layoutDropdown.addEventListener("change", updateNodeRepulsionVisibility);
 
-createSlider("nodeRepulsion-slider", 5, 1, 10, 1, (intValues) => {
+createSlider("nodeRepulsion-slider", defaultNodeRepulsion, 1, 10, 1, (intValues) => {
     nodeRepulsionValue = scaleToOriginalRange(intValues, nodeRepulsionMin, nodeRepulsionMax);
     componentSpacingValue = scaleToOriginalRange(intValues, componentSpacingMin, componentSpacingMax);
     document.getElementById("node-repulsion-value").textContent = intValues;


### PR DESCRIPTION
  ## Summary
  This PR addresses the "hairball" problem in Gene Symbol pages where dense networks
  become unreadable, with all nodes clustered into a single indistinguishable mass.

  ## Problem
  Gene Symbol pages display all genes connected to a target gene, resulting in
  extremely dense networks that provide no useful information due to overlapping nodes
   and edges.

  ## Solution
  Applied Gene Symbol-specific optimizations to the COSE layout algorithm and adjusted
   default display values.

  ### Layout Enhancements
  ```javascript
  // Enhanced COSE parameters for Gene Symbol pages only
  {
    idealEdgeLength: 100,      // Increase spacing between nodes
    gravity: -1.2,             // Negative gravity pushes nodes outward
    nodeOverlap: 20,           // Prevent node overlap
    numIter: 1500,             // More iterations for optimal layout
    initialTemp: 200,          // Better initial spreading
    // ... additional optimization parameters
  }
```

  Default Value Changes

  | Parameter      | Previous | New  | Reason                                |
  |----------------|----------|------|---------------------------------------|
  | Font size      | 20px     | 10px | Reduces label overlap                 |
  | Edge width     | 5        | 2    | Improves visibility in dense networks |
  | Node repulsion | 5        | 8    | Stronger initial spacing              |


  Implementation

  - Changes apply only to Gene Symbol pages via isGeneSymbolPage detection
  - Phenotype and Gene List pages remain unchanged
  - Modified files:
    - TSUMUGI/template/template-app-js/template_app.js
    - Example: app/genesymbol/Rab10.js

  Result

  Gene Symbol networks now display with proper spacing, making individual nodes and
  their connections clearly visible and analyzable.

  Testing

  Verified on multiple Gene Symbol pages (e.g., Rab10) that networks are now readable
  while ensuring other page types remain unaffected.